### PR TITLE
Segfault fix + small improvement 

### DIFF
--- a/src/diskmanager.cpp
+++ b/src/diskmanager.cpp
@@ -100,13 +100,20 @@ DiskManager::DiskManager(QObject *parent) :
 
     devs.waitForFinished();
 
-    foreach(const QDBusObjectPath& d, devs.value())
+    if (devs.isError())
     {
-        DeviceInfoPtr info = deviceForPath(d);
-        if (0 != info)
+        qDebug() << devs.error();
+    }
+    else
+    {
+        foreach(const QDBusObjectPath& d, devs.value())
         {
-            qDebug() << "Adding device to cache:" << d.path();
-            deviceCache.insert(d.path(), info);
+            DeviceInfoPtr info = deviceForPath(d);
+            if (0 != info)
+            {
+                qDebug() << "Adding device to cache:" << d.path();
+                deviceCache.insert(d.path(), info);
+            }
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
 
     processArgs(SUPPORTED_OPTIONS, "help", qApp->translate("TinyMountTray", "TinyMount, version %1").arg(TINYMOUNT_VERSION));
 
-    QApplication::setWindowIcon(QIcon(":/icons/tinymount.png"));
+    QApplication::setWindowIcon(QIcon::fromTheme("tinymount", QIcon(":/icons/tinymount.png")));
     TinyMountTray tmt;
 
     return app.exec();


### PR DESCRIPTION
Upon the connection error only a simple message is printed via the qDebug thingy. However, I don't know if running this application without the D-Bus connection is reasonable after all. Anyway, I think it's better then nasty segfault.

Nice app btw. It would be nice to have some kind of exclude list for "on-board" devices.

Cheers,
Arek
